### PR TITLE
Azure: Better handle "publish_preview" and "publish_live"

### DIFF
--- a/cloudpub/ms_azure/service.py
+++ b/cloudpub/ms_azure/service.py
@@ -7,7 +7,7 @@ from deepdiff import DeepDiff
 from requests import HTTPError
 from tenacity import retry
 from tenacity.retry import retry_if_result
-from tenacity.stop import stop_after_delay
+from tenacity.stop import stop_after_attempt, stop_after_delay
 from tenacity.wait import wait_chain, wait_fixed
 
 from cloudpub.common import BaseService
@@ -511,6 +511,11 @@ class AzureService(BaseService[AzurePublishingMetadata]):
             return current.id != live.id  # If they're the same then state == live
         return True  # when no live it means it's in preview
 
+    @retry(
+        wait=wait_fixed(wait=60),
+        stop=stop_after_attempt(3),
+        reraise=True,
+    )
     def _publish_preview(self, product: Product, product_name: str) -> None:
         """
         Submit the product to 'preview'  if it's not already in this state.
@@ -536,7 +541,17 @@ class AzureService(BaseService[AzurePublishingMetadata]):
             log.info(
                 "Submitting the product \"%s (%s)\" to \"preview\"." % (product_name, product.id)
             )
-            self.submit_to_status(product_id=product.id, status='preview')
+            res = self.submit_to_status(product_id=product.id, status='preview')
+
+            if res.job_result != 'succeeded' or not self.get_submission_state(
+                product.id, state="preview"
+            ):
+                errors = "\n".join(res.errors)
+                failure_msg = (
+                    f"Failed to submit the product {product.id} to preview. "
+                    f"Status: {res.job_result} Errors: {errors}"
+                )
+                raise RuntimeError(failure_msg)
 
     def _publish_live(self, product: Product, product_name: str) -> None:
         """

--- a/tests/ms_azure/test_service.py
+++ b/tests/ms_azure/test_service.py
@@ -1312,6 +1312,7 @@ class TestAzureService:
             mock_substt.assert_called_once_with(current.product_id, "live")
 
     @mock.patch("cloudpub.ms_azure.AzureService.ensure_can_publish")
+    @mock.patch("cloudpub.ms_azure.AzureService.get_submission_state")
     @mock.patch("cloudpub.ms_azure.AzureService.diff_offer")
     @mock.patch("cloudpub.ms_azure.AzureService.configure")
     @mock.patch("cloudpub.ms_azure.AzureService.submit_to_status")
@@ -1330,6 +1331,7 @@ class TestAzureService:
         mock_submit: mock.MagicMock,
         mock_configure: mock.MagicMock,
         mock_diff_offer: mock.MagicMock,
+        mock_getsubst: mock.MagicMock,
         mock_ensure_publish: mock.MagicMock,
         product_obj: Product,
         plan_summary_obj: PlanSummary,
@@ -1349,6 +1351,11 @@ class TestAzureService:
             [technical_config_obj],
             [submission_obj],
         ]
+        mock_getsubst.side_effect = ["preview", "live"]
+        mock_res_preview = mock.MagicMock()
+        mock_res_live = mock.MagicMock()
+        mock_res_preview.job_result = mock_res_live.job_result = "succeeded"
+        mock_submit.side_effect = [mock_res_preview, mock_res_live]
         mock_is_sas.return_value = False
         expected_source = VMImageSource(
             source_type="sasUri",
@@ -1365,6 +1372,7 @@ class TestAzureService:
         technical_config_obj.disk_versions = [disk_version_obj]
         technical_config_obj.disk_versions = [disk_version_obj]
 
+        # Test
         azure_service.publish(metadata_azure_obj)
         mock_getprpl_name.assert_called_once_with("example-product", "plan-1")
         filter_calls = [

--- a/tests/ms_azure/test_service.py
+++ b/tests/ms_azure/test_service.py
@@ -901,6 +901,66 @@ class TestAzureService:
         with pytest.raises(RuntimeError, match=expected_err):
             azure_service._publish_preview(product_obj, "test-product")
 
+    @mock.patch("cloudpub.ms_azure.AzureService.get_submission_state")
+    @mock.patch("cloudpub.ms_azure.AzureService.submit_to_status")
+    def test_publish_live_success_on_retry(
+        self,
+        mock_subst: mock.MagicMock,
+        mock_getsubst: mock.MagicMock,
+        product_obj: Product,
+        azure_service: AzureService,
+    ) -> None:
+        # Prepare mocks
+        mock_config_res = mock.MagicMock()
+        mock_config_res.job_result = "succeeded"
+        mock_subst.side_effect = [mock_config_res for _ in range(3)]
+        mock_getsubst.side_effect = [
+            None,  # Fail on 1st call
+            None,
+            mock.MagicMock(),  # Success on 3rd call
+        ]
+        # Remove the retry sleep
+        azure_service._publish_live.retry.sleep = mock.Mock()  # type: ignore
+
+        # Test
+        azure_service._publish_live(product_obj, "test-product")
+
+        mock_subst.assert_has_calls(
+            [mock.call(product_id=product_obj.id, status="live") for _ in range(3)]
+        )
+        mock_getsubst.assert_has_calls([mock.call(product_obj.id, state="live") for _ in range(3)])
+
+    @mock.patch("cloudpub.ms_azure.AzureService.get_submission_state")
+    @mock.patch("cloudpub.ms_azure.AzureService.submit_to_status")
+    def test_publish_live_fail_on_retry(
+        self,
+        mock_subst: mock.MagicMock,
+        mock_getsubst: mock.MagicMock,
+        product_obj: Product,
+        azure_service: AzureService,
+    ) -> None:
+        # Prepare mocks
+        err_resp = ConfigureStatus.from_json(
+            {
+                "jobId": "1",
+                "jobStatus": "completed",
+                "jobResult": "failed",
+                "errors": ["failure1", "failure2"],
+            }
+        )
+        mock_subst.side_effect = [err_resp for _ in range(3)]
+        mock_getsubst.side_effect = [None for _ in range(3)]
+        # Remove the retry sleep
+        azure_service._publish_live.retry.sleep = mock.Mock()  # type: ignore
+        expected_err = (
+            f"Failed to submit the product {product_obj.id} to live. "
+            "Status: failed Errors: failure1\nfailure2"
+        )
+
+        # Test
+        with pytest.raises(RuntimeError, match=expected_err):
+            azure_service._publish_live(product_obj, "test-product")
+
     @mock.patch("cloudpub.ms_azure.AzureService.configure")
     @mock.patch("cloudpub.ms_azure.AzureService.submit_to_status")
     @mock.patch("cloudpub.ms_azure.service.update_skus")


### PR DESCRIPTION
This PR enhances the Azure publishing mechanism introducing retries for failed operations.

With this change, the `AzureService` methods `_publish_preview` and `publish_live` will ensure the submission status was changed to the desired target and, if it's not the case, retry the operation up to 3 times.

Finally, it removes a leftover condition from the no longer existing `stage_preveiw` feature.

Refers to SPSTRAT-288