### PR TITLE
Azure: Remove unnecessary "AZURE_PUBLISHER_NAME"

### DIFF
--- a/cloudpub/ms_azure/session.py
+++ b/cloudpub/ms_azure/session.py
@@ -66,7 +66,6 @@ class PartnerPortalSession:
         self.resource = base_url(prefix_url)
         self._mandatory_params = mandatory_params
         self._token: Optional[AccessToken] = None
-        self.publisher = auth_keys["AZURE_PUBLISHER_NAME"]
         self._additional_args = kwargs
         self.session = requests.Session()
         total_retries = kwargs.pop("total_retries", 5)
@@ -104,7 +103,6 @@ class PartnerPortalSession:
     def _validate_auth_keys(auth_keys: Dict[str, str]) -> Dict[str, str]:
         """Validate whether auth_keys contains all required keys."""
         mandatory_keys = [
-            "AZURE_PUBLISHER_NAME",
             "AZURE_CLIENT_ID",
             "AZURE_TENANT_ID",
             "AZURE_API_SECRET",

--- a/tests/ms_azure/test_session.py
+++ b/tests/ms_azure/test_session.py
@@ -33,7 +33,6 @@ class TestPartnerPortalSession:
 
     def test_make_session_invalid_auth_dict(self, auth_dict: Dict[str, str]) -> None:
         keys = [
-            "AZURE_PUBLISHER_NAME",
             "AZURE_CLIENT_ID",
             "AZURE_TENANT_ID",
             "AZURE_API_SECRET",


### PR DESCRIPTION
During 1p tests we found out that the `AZURE_PUBLISHER_NAME` for Azure Credentials wasn't being used at all in the library's code.

After doing some tests I've confirmed this property is not required, so this commit removes it.