### PR TITLE
Azure: Only publish when changes were made

### DIFF
--- a/cloudpub/ms_azure/service.py
+++ b/cloudpub/ms_azure/service.py
@@ -637,8 +637,8 @@ class AzureService(BaseService[AzurePublishingMetadata]):
                 disk_version = create_disk_version_from_scratch(metadata, source)
                 tech_config.disk_versions.append(disk_version)
         else:
-            log.debug(
-                "The destination \"%s\" already contains the SAS URI: \"%s\""
+            log.info(
+                "The destination \"%s\" already contains the SAS URI: \"%s\"."
                 % (metadata.destination, metadata.image_path)
             )
 
@@ -655,7 +655,8 @@ class AzureService(BaseService[AzurePublishingMetadata]):
             self.configure(resource=tech_config)
 
         # 5. Proceed to publishing if it was requested.
-        if not metadata.keepdraft:
+        # Note: The publishing will only occur if it made changes in disk_version.
+        if disk_version and not metadata.keepdraft:
             logdiff(self.diff_offer(product))
             self.ensure_can_publish(product.id)
 

--- a/tests/ms_azure/test_service.py
+++ b/tests/ms_azure/test_service.py
@@ -1084,6 +1084,7 @@ class TestAzureService:
         mock_configure.assert_called_once_with(resource=expected_tech_config)
         mock_submit.assert_not_called()
 
+    @pytest.mark.parametrize("keepdraft", [True, False], ids=["nochannel", "push"])
     @mock.patch("cloudpub.ms_azure.AzureService.configure")
     @mock.patch("cloudpub.ms_azure.AzureService.submit_to_status")
     @mock.patch("cloudpub.ms_azure.service.update_skus")
@@ -1102,6 +1103,7 @@ class TestAzureService:
         mock_upd_sku: mock.MagicMock,
         mock_submit: mock.MagicMock,
         mock_configure: mock.MagicMock,
+        keepdraft: bool,
         product_obj: Product,
         plan_summary_obj: PlanSummary,
         metadata_azure_obj: AzurePublishingMetadata,
@@ -1110,7 +1112,7 @@ class TestAzureService:
         azure_service: AzureService,
     ) -> None:
         metadata_azure_obj.overwrite = False
-        metadata_azure_obj.keepdraft = True
+        metadata_azure_obj.keepdraft = keepdraft
         metadata_azure_obj.destination = "example-product/plan-1"
         metadata_azure_obj.disk_version = "2.0.0"
         mock_getprpl_name.return_value = product_obj, plan_summary_obj


### PR DESCRIPTION
This commit changes the `AzureService.publish` method to only request the publish preview/live whenever there was a change made into a plan, it is, whenever a SAS VM image was set.

Refers to SPSTRAT-375