### PR TITLE
Azure: Return original SKU if Gen1 & Gen2 are set

### DIFF
--- a/cloudpub/ms_azure/utils.py
+++ b/cloudpub/ms_azure/utils.py
@@ -295,6 +295,12 @@ def update_skus(
             disk_versions, default_gen=generation, alt_gen=alt_gen, plan_name=plan_name
         )
 
+    # If we have SKUs for both genenerations we don't need to update them as they're already
+    # properly set.
+    if len(old_skus) == 2:
+        return old_skus
+
+    # Update SKUs to create the alternate gen.
     # The security type may exist only for Gen2, so it iterates over all gens to find it
     security_type = None
     # The alternate plan name ends with the suffix "-genX" and we can't change that once

--- a/tests/ms_azure/test_utils.py
+++ b/tests/ms_azure/test_utils.py
@@ -232,6 +232,13 @@ class TestAzureUtils:
         self, technical_config_obj: VMIPlanTechConfig, metadata_azure_obj: AzurePublishingMetadata
     ) -> None:
         """Test for a "SKU update" from scratch."""
+        skus = [
+            VMISku.from_json(x)
+            for x in [
+                {"imageType": "x64Gen1", "skuId": "plan-1-gen1"},
+            ]
+        ]
+        technical_config_obj.skus = skus
         res = update_skus(
             disk_versions=technical_config_obj.disk_versions,
             generation=metadata_azure_obj.generation,
@@ -252,7 +259,6 @@ class TestAzureUtils:
         skus = [
             VMISku.from_json(x)
             for x in [
-                {"imageType": "x64Gen1", "skuId": "plan1"},
                 {"imageType": "x64Gen2", "skuId": "plan1-gen2", "securityType": ["trusted"]},
             ]
         ]


### PR DESCRIPTION
This commit updates the `ms_azure.utils.update_skus` to not update the SKUs if both Gen1 and Gen2 are provided, instead it will return them to prevent erros by trying to change the SKU names with a possible new one which follows the strict naming convention.

Refers to SPSTRAT-416