### PR TITLE
Fix update_skus bug when a single gen is set

### DIFF
--- a/tests/ms_azure/test_utils.py
+++ b/tests/ms_azure/test_utils.py
@@ -277,6 +277,46 @@ class TestAzureUtils:
             ]
         ]
 
+    @pytest.mark.parametrize("generation", ["V1", "V2"])
+    def test_update_existing_skus_gen1_single(
+        self, generation: str, technical_config_obj: VMIPlanTechConfig
+    ) -> None:
+        skus = [VMISku.from_json({"imageType": "x64Gen1", "skuId": "plan1"})]
+        technical_config_obj.skus = skus
+        res = update_skus(
+            disk_versions=technical_config_obj.disk_versions,
+            generation=generation,
+            plan_name="plan1",
+            old_skus=technical_config_obj.skus,
+        )
+        assert res == [
+            VMISku.from_json(x)
+            for x in [
+                {"imageType": "x64Gen1", "skuId": "plan1", "securityType": None},
+                {"imageType": "x64Gen2", "skuId": "plan1-gen2", "securityType": None},
+            ]
+        ]
+
+    @pytest.mark.parametrize("generation", ["V1", "V2"])
+    def test_update_existing_skus_gen2_single(
+        self, generation: str, technical_config_obj: VMIPlanTechConfig
+    ) -> None:
+        skus = [VMISku.from_json({"imageType": "x64Gen2", "skuId": "plan1"})]
+        technical_config_obj.skus = skus
+        res = update_skus(
+            disk_versions=technical_config_obj.disk_versions,
+            generation=generation,
+            plan_name="plan1",
+            old_skus=technical_config_obj.skus,
+        )
+        assert res == [
+            VMISku.from_json(x)
+            for x in [
+                {"imageType": "x64Gen2", "skuId": "plan1", "securityType": None},
+                {"imageType": "x64Gen1", "skuId": "plan1-gen1", "securityType": None},
+            ]
+        ]
+
     def test_create_disk_version_from_scratch(
         self,
         disk_version_obj: DiskVersion,


### PR DESCRIPTION
This commit fixes a bug on `update_skus` which happens whenever a plan has just a single generation set on SKU.

In the previous versions it was looking only for the SKU ID suffix to determine the default and alternate gen, which was enough for all cases with 2 generations defined but would cause a bug (renaming the SKU ID) whenever a single generation was originally set.

With this fix it looks not only in the SKU ID suffix but also on SKU image type to determine which generation is the default and which is the alternate to prevent renaming the default.

Refers to SPSTRAT-462