### PR TITLE
Azure: Add missing alias for dateOffset

### DIFF
--- a/cloudpub/models/ms_azure.py
+++ b/cloudpub/models/ms_azure.py
@@ -256,7 +256,7 @@ class DeprecationSchedule(AttrsJSONDecodeMixin):
     """The date for deprecation."""
 
     date_offset: Optional[str] = field(
-        validator=optional(instance_of(str)), metadata={"hide_unset": True}
+        validator=optional(instance_of(str)), metadata={"hide_unset": True, "alias": "dateOffset"}
     )
     """The date offset for deprecation."""
 


### PR DESCRIPTION
This commit adds a missing alias for the `date_offset` property on `DeprecationSchedule`. Without this alias the class was unable to properly parse the value from JSON, which may cause the following error when senting the request to configure:

```
'badRequest', 'message': "The deprecation schedule for image 'X.Y.Z' of type 'ARCH' is already published and can not be changed in draft."
```

Refers to SPMM-18578