### PR TITLE
Update OWASP dependency check URL

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -108,8 +108,8 @@ jobs:
           restore-keys: ${{ runner.os }}-build-owasp-
       - name: OWASP check
         run: |
-          VERSION=$(curl -s https://jeremylong.github.io/DependencyCheck/current.txt)
-          curl -L "https://github.com/jeremylong/DependencyCheck/releases/download/v$VERSION/dependency-check-$VERSION-release.zip" --output dependency-check.zip
+          VERSION=$(curl -s https://dependency-check.github.io/DependencyCheck/current.txt)
+          curl -Ls "https://github.com/dependency-check/DependencyCheck/releases/download/v$VERSION/dependency-check-$VERSION-release.zip" --output dependency-check.zip
           unzip -o dependency-check.zip
           rm -f dependency-check.zip
           ./dependency-check/bin/dependency-check.sh \

--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -116,6 +116,7 @@ jobs:
           --project "starmap-client" \
           --out "dependency-check" \
           --format "ALL" \
+          --nvdApiKey ${{ secrets.OWASP_API_KEY }} \
           --enableExperimental \
           --scan . \
           --data .code_scanning/dependency-check/data \


### PR DESCRIPTION
As stated in the `jeremylong` repository:

```
The OWASP DependencyCheck project has moved to https://github.com/dependency-check/DependencyCheck/. Please update any automation that points to the old repository.
```

This commit updates the URL for OWASP check.