### PR TITLE
Azure: Fix bug with security_type on ARM64

### DIFF
--- a/cloudpub/ms_azure/utils.py
+++ b/cloudpub/ms_azure/utils.py
@@ -281,6 +281,12 @@ def _build_skus(
             return plan_name
         return f"{plan_name}-{arch.lower()}"
 
+    def get_safe_security_type(image_type):
+        # Arches which aren't x86Gen2 (like ARM64) doesn't work well with security type
+        if image_type != "x64Gen2":
+            return None
+        return security_type
+
     sku_mapping: Dict[str, str] = {}
     # Update the SKUs for each image in DiskVersions if needed
     for disk_version in disk_versions:
@@ -301,7 +307,7 @@ def _build_skus(
 
     # Return the expected SKUs list
     res = [
-        VMISku.from_json({"image_type": k, "id": v, "security_type": security_type})
+        VMISku.from_json({"image_type": k, "id": v, "security_type": get_safe_security_type(k)})
         for k, v in sku_mapping.items()
     ]
     return sorted(res, key=attrgetter("id"))


### PR DESCRIPTION
This commit fixes a bug on SKU building for Azure which prevents ARM64 images to be published.

Bsically the `securityType` field may only be applied to `X86Gen2` image types when set, so this patch disables it for any different kind of image type.

Refers to STRAT-2425