### PR TITLE
Azure: Fix bug on update_skus

### DIFF
--- a/cloudpub/ms_azure/utils.py
+++ b/cloudpub/ms_azure/utils.py
@@ -262,11 +262,16 @@ def prepare_vm_images(
         return [VMImageDefinition.from_json(json_gen1)]
 
 
-def _len_vm_images(disk_versions: List[DiskVersion]) -> int:
-    count = 0
-    for disk_version in disk_versions:
-        count = count + len(disk_version.vm_images)
-    return count
+def _all_skus_present(old_skus: List[VMISku], disk_versions: List[DiskVersion]) -> bool:
+    image_types = set()
+    for sku in old_skus:
+        image_types.add(sku.image_type)
+
+    for dv in disk_versions:
+        for img in dv.vm_images:
+            if img.image_type not in image_types:
+                return False
+    return True
 
 
 def _build_skus(
@@ -352,7 +357,7 @@ def update_skus(
 
     # If we have SKUs for each image we don't need to update them as they're already
     # properly set.
-    if len(old_skus) == _len_vm_images(disk_versions):
+    if _all_skus_present(old_skus, disk_versions):
         return old_skus
 
     # Update SKUs to create the alternate gen.

--- a/tests/ms_azure/test_utils.py
+++ b/tests/ms_azure/test_utils.py
@@ -484,6 +484,34 @@ class TestAzureUtils:
             ]
         ]
 
+    @pytest.mark.parametrize("generation", ["V1", "V2"])
+    def test_update_skus_return_existing_unconventional_naming(
+        self,
+        generation: str,
+        technical_config_obj: VMIPlanTechConfig,
+    ) -> None:
+        """Ensure the existing SKUs are returned even if they doesn't present expected namings."""
+        skus = [
+            VMISku.from_json(x)
+            for x in [
+                {"imageType": "x64Gen2", "skuId": "differentNaming"},
+                {"imageType": "x64Gen1", "skuId": "gen1GotDifferentNaming"},
+            ]
+        ]
+        res = update_skus(
+            disk_versions=technical_config_obj.disk_versions,
+            generation=generation,
+            plan_name="plan1",
+            old_skus=skus,
+        )
+        assert res == [
+            VMISku.from_json(x)
+            for x in [
+                {"imageType": "x64Gen2", "skuId": "differentNaming", "securityType": None},
+                {"imageType": "x64Gen1", "skuId": "gen1GotDifferentNaming"},
+            ]
+        ]
+
     def test_create_disk_version_from_scratch_x86(
         self,
         disk_version_obj: DiskVersion,


### PR DESCRIPTION
This commit fixes the decision criteria to return the existing SKUs instead of creating new ones on `update_skus`.

The old command was trying to infer the number of the disk images for each version, which is not the correct way of doing this nor was properly working.

The new criteria is the following:

1. The private method _all_skus_present will evaluate which image types are already declared in the SKUs
2. If there's a disk versino which contains an image which declares a type not already present in the SKUs it will return `False`, indicating the need to generate the new SKUs and `True` otherwise.

Refers to SPSTRAT-514