### PR TITLE
Azure: Allow partial SAS comparison

### DIFF
--- a/cloudpub/ms_azure/service.py
+++ b/cloudpub/ms_azure/service.py
@@ -620,7 +620,7 @@ class AzureService(BaseService[AzurePublishingMetadata]):
             tech_config.disk_versions = [disk_version]
 
         # We just want to append a new image if the SAS is not already present.
-        elif not is_sas_present(tech_config, metadata.image_path):
+        elif not is_sas_present(tech_config, metadata.image_path, metadata.check_base_sas_only):
             # Here we can have the metadata.disk_version set or empty.
             # When set we want to get the existing disk_version which matches its value.
             log.debug("Scanning the disk versions from %s" % metadata.destination)

--- a/tests/ms_azure/test_service.py
+++ b/tests/ms_azure/test_service.py
@@ -1076,7 +1076,9 @@ class TestAzureService:
         mock_filter.assert_called_once_with(
             product=product_obj, resource="virtual-machine-plan-technical-configuration"
         )
-        mock_is_sas.assert_called_once_with(technical_config_obj, metadata_azure_obj.image_path)
+        mock_is_sas.assert_called_once_with(
+            technical_config_obj, metadata_azure_obj.image_path, False
+        )
         mock_prep_img.assert_not_called()
         mock_upd_sku.assert_called_once_with(
             disk_versions=expected_tech_config.disk_versions,
@@ -1134,6 +1136,7 @@ class TestAzureService:
         mock_is_sas.assert_called_once_with(
             technical_config_obj,
             metadata_azure_obj.image_path,
+            False,
         )
         mock_prep_img.assert_not_called()
         mock_disk_scratch.assert_not_called()
@@ -1202,6 +1205,7 @@ class TestAzureService:
         mock_is_sas.assert_called_once_with(
             technical_config_obj,
             metadata_azure_obj.image_path,
+            False,
         )
         mock_prep_img.assert_not_called()
         mock_disk_scratch.assert_not_called()
@@ -1267,6 +1271,7 @@ class TestAzureService:
         mock_is_sas.assert_called_once_with(
             technical_config_obj,
             metadata_azure_obj.image_path,
+            False,
         )
         mock_prep_img.assert_called_once_with(
             metadata=metadata_azure_obj,
@@ -1389,6 +1394,7 @@ class TestAzureService:
         mock_is_sas.assert_called_once_with(
             technical_config_obj,
             metadata_azure_obj.image_path,
+            False,
         )
         mock_prep_img.assert_called_once_with(
             metadata=metadata_azure_obj,
@@ -1479,6 +1485,7 @@ class TestAzureService:
         mock_is_sas.assert_called_once_with(
             technical_config_obj,
             metadata_azure_obj.image_path,
+            False,
         )
         mock_prep_img.assert_called_once_with(
             metadata=metadata_azure_obj,

--- a/tests/ms_azure/test_utils.py
+++ b/tests/ms_azure/test_utils.py
@@ -102,31 +102,65 @@ class TestAzureUtils:
         assert res == "x64Gen2"
 
     @pytest.mark.parametrize(
-        "sas1,sas2,expected",
+        "sas1,sas2,base_only,expected",
         [
-            ("https://foo.com/bar", "https://foo.com/bar?foo=bar", False),
-            ("https://foo.com/bar?foo=bar&st=aaaaa", "https://foo.com/bar?foo=bar&st=bbb", True),
+            ("https://foo.com/bar", "https://foo.com/bar?foo=bar", False, False),
+            (
+                "https://foo.com/bar?foo=bar&st=aaaaa",
+                "https://foo.com/bar?foo=bar&st=bbb",
+                False,
+                True,
+            ),
             (
                 "https://foo.com/bar?foo=bar&st=a&se=b&sig=c&bar=foo",
                 "https://foo.com/bar?foo=bar&st=d&se=e&sig=f&bar=foo",
+                False,
                 True,
             ),
             (
                 "https://foo.com/bar?foo=bar&st=a&se=b&sig=c&bar=foo",
                 "https://foo.com/bar?foo=foo&st=d&se=e&sig=f",
                 False,
+                False,
             ),
-            ("https://foo.com/bar?foo=bar&st=aaaaa", "https://bar.com/foo?foo=bar&st=bbb", False),
-            ("https://foo.com/bar?bar=foo&st=aaaaa", "https://foo.com/bar?foo=bar&st=bbb", False),
+            (
+                "https://foo.com/bar?foo=bar&st=aaaaa",
+                "https://bar.com/foo?foo=bar&st=bbb",
+                False,
+                False,
+            ),
+            (
+                "https://foo.com/bar?bar=foo&st=aaaaa",
+                "https://foo.com/bar?foo=bar&st=bbb",
+                False,
+                False,
+            ),
+            (
+                "https://foo.com/bar?foo=bar&st=aaaaa",
+                "https://bar.com/foo?foo=bar&st=bbb",
+                True,
+                False,
+            ),
+            (
+                "https://foo.com/bar?bar=foo&st=aaaaa",
+                "https://foo.com/bar?foo=bar&st=bbb",
+                True,
+                True,
+            ),
         ],
     )
     def test_is_sas_present(
-        self, sas1: str, sas2: str, expected: bool, technical_config_obj: VMIPlanTechConfig
+        self,
+        sas1: str,
+        sas2: str,
+        base_only: bool,
+        expected: bool,
+        technical_config_obj: VMIPlanTechConfig,
     ) -> None:
         # Test positive
         technical_config_obj.disk_versions[0].vm_images[0].source.os_disk.uri = sas1
 
-        res = is_sas_present(tech_config=technical_config_obj, sas_uri=sas2)
+        res = is_sas_present(tech_config=technical_config_obj, sas_uri=sas2, base_only=base_only)
         assert res is expected
 
     def test_prepare_vm_images_gen1(


### PR DESCRIPTION
This commit changes the Azure's implementation `utils.is_sas_present` function to have a new boolean argument named `base_only` which defaults to `False`. When set as `True` it will cause the SAS comparison to not check for its arguments equivalence, rather just whether the SAS URI part is the same or not.

It also changes the `AzurePublishingMetadata` to include a new property named `check_base_sas_only` to transmit its boolean value to the `utils.is_sas_present` function.

In practice, this allows the library to have a more permissive SAS comparison when required while maintaning the existing behavior as default.