### PR TITLE
SPSTRAT-549: Azure: Retry publishing when a submission is in progress/conflict

### DIFF
--- a/cloudpub/error.py
+++ b/cloudpub/error.py
@@ -17,6 +17,14 @@ class InvalidStateError(RuntimeError):
     """Report invalid state which should not happen in code."""
 
 
+class ConflictError(Exception):
+    """Report a submission conflict error."""
+
+
+class RunningSubmissionError(Exception):
+    """Report a running submission error."""
+
+
 class NotFoundError(ValueError):
     """Represent a missing resource."""
 

--- a/cloudpub/models/ms_azure.py
+++ b/cloudpub/models/ms_azure.py
@@ -29,6 +29,20 @@ def _mask_secret(value: str) -> str:
 
 
 @define
+class ConfigureError(AttrsJSONDecodeMixin):
+    """Represent an error from a :meth:`~AzureService.configure` request."""
+
+    code: str
+    """The error code."""
+
+    message: str
+    """The error message."""
+
+    resource_id: str = field(metadata={"alias": "resourceId"})
+    """The resource ID."""
+
+
+@define
 class ConfigureStatus(AttrsJSONDecodeMixin):
     """Represent a response from a :meth:`~AzureService.configure` request."""
 
@@ -67,7 +81,10 @@ class ConfigureStatus(AttrsJSONDecodeMixin):
     resource_uri: Optional[str] = field(metadata={"alias": "resourceUri", "hide_unset": True})
     """The resource URI related to the configure job."""
 
-    errors: List[str]
+    errors: List[ConfigureError] = field(
+        converter=lambda x: [ConfigureError.from_json(r) for r in x] if x else [],
+        on_setattr=NO_OP,
+    )
     """List of errors when the ``job_result`` is ``failed``."""
 
 

--- a/tests/ms_azure/conftest.py
+++ b/tests/ms_azure/conftest.py
@@ -92,11 +92,48 @@ def job_details_completed_failure(errors: List[Dict[str, Any]]) -> Dict[str, Any
 
 
 @pytest.fixture
+def job_details_completed_conflict(errors_conflict: List[Dict[str, Any]]) -> Dict[str, Any]:
+    return job_details(status="completed", result="failed", errors=errors_conflict)
+
+
+@pytest.fixture
+def job_details_completed_running_submission(
+    errors_running_submission: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    return job_details(status="completed", result="failed", errors=errors_running_submission)
+
+
+@pytest.fixture
 def errors() -> List[Dict[str, Any]]:
     return [
         {
+            "resourceId": "resource-id",
+            "code": "internalServerError",
+            "message": "A catastrophic error occurred.",
+            "details": [{"code": "invalidResource", "message": "Failure for resource"}],
+        }
+    ]
+
+
+@pytest.fixture
+def errors_running_submission() -> List[Dict[str, Any]]:
+    return [
+        {
+            "resourceId": "resource-id",
+            "code": "internalServerError",
+            "message": "An In Progress submission 1234567890 already exists.",
+            "details": [{"code": "invalidResource", "message": "Failure for resource"}],
+        }
+    ]
+
+
+@pytest.fixture
+def errors_conflict() -> List[Dict[str, Any]]:
+    return [
+        {
+            "resourceId": "resource-id",
             "code": "conflict",
-            "message": "Error message",
+            "message": "The submission cannot be pushed to live as its not the latest submission.",
             "details": [{"code": "invalidResource", "message": "Failure for resource"}],
         }
     ]
@@ -132,6 +169,7 @@ def configure_success_response() -> Dict[str, Any]:
 def configure_failure_response() -> Dict[str, Any]:
     return {
         "error": {
+            "resourceId": "resource-id",
             "code": "badRequest",
             "message": "Invalid configuration: schema validation failed",
             "details": [
@@ -617,3 +655,17 @@ def job_details_completed_failure_obj(
     job_details_completed_failure: Dict[str, Any],
 ) -> ConfigureStatus:
     return ConfigureStatus.from_json(job_details_completed_failure)
+
+
+@pytest.fixture
+def job_details_completed_conflict_obj(
+    job_details_completed_conflict: Dict[str, Any],
+) -> ConfigureStatus:
+    return ConfigureStatus.from_json(job_details_completed_conflict)
+
+
+@pytest.fixture
+def job_details_completed_running_submission_obj(
+    job_details_completed_running_submission: Dict[str, Any],
+) -> ConfigureStatus:
+    return ConfigureStatus.from_json(job_details_completed_running_submission)


### PR DESCRIPTION
This commit changes the Azure module to retry publishing the VM image whenever a submission in progress/conflict happens.
    
It will first attempt to change the target to `preview` or `live` for 3 times and then, if the exception comes as `ConflictError` or `RunningSubmissionError` it will restart the publishing task.

In order to accomplish that it introduces new models/exceptions for handling fine grained errors from Azure API as well as some new functions in `utils` to detect whether an operation in progress/conflict error is sent.


Refers to SPSTRAT-549