### PR TITLE
Azure: Improve logs output

### DIFF
--- a/cloudpub/ms_azure/session.py
+++ b/cloudpub/ms_azure/session.py
@@ -117,7 +117,7 @@ class PartnerPortalSession:
 
     def _login(self) -> AccessToken:
         """Retrieve the authentication token from Microsoft."""
-        log.info("Retrieving the bearer token from Microsoft")
+        log.debug("Retrieving the bearer token from Microsoft")
         url = self.LOGIN_URL_TMPL.format(**self.auth_keys)
 
         headers = {
@@ -156,7 +156,7 @@ class PartnerPortalSession:
                 params = {}
             params.update(self._mandatory_params)
 
-        log.info(f"Sending a {method} request to {path}")
+        log.debug(f"Sending a {method} request to {path}")
         formatted_url = self._prefix_url.format(**self.auth_keys)
         url = join_url(formatted_url, path)
         return self.session.request(method, url=url, params=params, headers=headers, **kwargs)

--- a/cloudpub/ms_azure/utils.py
+++ b/cloudpub/ms_azure/utils.py
@@ -556,13 +556,14 @@ def set_new_sas_disk_version(
     Returns:
         The changed disk version with the given source.
     """
+    log.info("Setting up a new SAS disk version for \"%s\"", metadata.image_path)
     # If we already have a VMImageDefinition let's use it
     if disk_version.vm_images:
         log.debug("The DiskVersion \"%s\" contains inner images." % disk_version.version_number)
         img, img_legacy = vm_images_by_generation(disk_version, metadata.architecture)
 
         # Now we replace the SAS URI for the vm_images
-        log.debug(
+        log.info(
             "Adjusting the VMImages from existing DiskVersion \"%s\""
             "to fit the new image with SAS \"%s\"."
             % (disk_version.version_number, metadata.image_path)
@@ -579,7 +580,7 @@ def set_new_sas_disk_version(
         log.debug(
             "The DiskVersion \"%s\" does not contain inner images." % disk_version.version_number
         )
-        log.debug(
+        log.info(
             "Setting the new image \"%s\" on DiskVersion \"%s\"."
             % (metadata.image_path, disk_version.version_number)
         )


### PR DESCRIPTION
- Move some useful logs out of `DEBUG` to `INFO`
- Add the image path in some logs lines as it's hard to know what it's doing in a multi-thread scenario
- Unify the logs for `submit_to_status` instead of having a "copy/paste" code on `_publish_preview` and `_publish_live`
- Remove unnecessary identation on `_publish_preview` by simply inverting the `if` condition and logging/returning when the product is already in preview. This saves identation lines and keeps the code more organized

## Summary by Sourcery

Improve logging in Azure service by elevating key operations to INFO, adding image path context, standardizing status submission logs, and refactoring publish preview logic for clarity.

Enhancements:
- Elevate logs for product listing, submission status lookup, technical config retrieval, SKU updates, and publish steps to INFO
- Include image_path and product identifiers in INFO logs to clarify multi-threaded operations
- Demote verbose logs (configuration dumps, HTTP requests, token retrieval) to DEBUG to reduce noise
- Standardize logging in submit_to_status and consolidate duplicate code in publish_preview and publish_live
- Refactor _publish_preview to invert its condition and return early when already in preview, reducing indentation
- Add final INFO log confirming completion of image publishing
- Promote utility logs in set_new_sas_disk_version to INFO for SAS disk version setup