### PR TITLE
Release v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.7.1 - 2026-04-27
+
+- AWS: Fix bug on PromotionalResources model by @JAVGan in https://github.com/release-engineering/cloudpub/pull/180
+- Azure: Add default timeout of 5s for all requests by @JAVGan in https://github.com/release-engineering/cloudpub/pull/188
+- Bump dependencies
+
 ## 1.7.0 - 2026-02-06
 
 - feature: Add "offline" diff for AzureService by @JAVGan in https://github.com/release-engineering/cloudpub/pull/152

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name='cloudpub',
     description='Services for publishing products in cloud environments',
-    version='1.7.0',
+    version='1.7.1',
     keywords='stratosphere cloudpub cloudpublish',
     author='Jonathan Gangi',
     author_email='jgangi@redhat.com',


### PR DESCRIPTION
Changes:

- AWS: Fix bug on PromotionalResources model by @JAVGan in https://github.com/release-engineering/cloudpub/pull/180
- Azure: Add default timeout of 5s for all requests by @JAVGan in https://github.com/release-engineering/cloudpub/pull/188
- Bump dependencies

## Summary by Sourcery

Prepare v1.7.1 release by updating changelog and package version metadata.

Bug Fixes:
- Document AWS PromotionalResources model bug fix included in this release.

Enhancements:
- Document Azure default 5s request timeout and dependency upgrades for this release.

Build:
- Bump package version to 1.7.1 in setup configuration.