### PR TITLE
Azure: Rework the PartnerPortalSession Retries

### DIFF
--- a/cloudpub/ms_azure/session.py
+++ b/cloudpub/ms_azure/session.py
@@ -5,13 +5,33 @@ from datetime import datetime
 from typing import Any, Dict, Optional
 
 import requests
-from requests.adapters import HTTPAdapter, Retry
+from tenacity import (
+    retry,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 from cloudpub.utils import base_url, join_url
 
 log = logging.getLogger(__name__)
 
 AZURE_SESSION_TIMEOUT: float = float(os.environ.get("AZURE_SESSION_TIMEOUT", 5.0))
+AZURE_TOTAL_RETRIES: int = int(os.environ.get("AZURE_TOTAL_RETRIES", 5))
+AZURE_BACKOFF_FACTOR: float = float(os.environ.get("AZURE_BACKOFF_FACTOR", 1.0))
+# Inclusive range of HTTP response status codes for which _request retries.
+AZURE_RETRY_HTTP_STATUS_MIN: int = 408
+AZURE_RETRY_HTTP_STATUS_MAX: int = 512
+
+
+def _should_retry_request_http_error(exc: BaseException) -> bool:
+    if not isinstance(exc, requests.exceptions.HTTPError):
+        return False
+    err_response = exc.response
+    if err_response is None:
+        return False
+    code = err_response.status_code
+    return AZURE_RETRY_HTTP_STATUS_MIN <= code <= AZURE_RETRY_HTTP_STATUS_MAX
 
 
 class AccessToken:
@@ -71,15 +91,6 @@ class PartnerPortalSession:
         self._token: Optional[AccessToken] = None
         self._additional_args = kwargs
         self.session = requests.Session()
-        total_retries = kwargs.pop("total_retries", 5)
-        backoff_factor = kwargs.pop("backoff_factor", 1)
-        status_forcelist = kwargs.pop("status_forcelist", tuple(range(500, 512)))
-        retries = Retry(
-            total=total_retries,
-            backoff_factor=backoff_factor,
-            status_forcelist=status_forcelist,
-        )
-        self.session.mount('https://', HTTPAdapter(max_retries=retries))
 
     @classmethod
     def make_graph_api_session(
@@ -145,6 +156,12 @@ class PartnerPortalSession:
         log.debug("Serving the bearer token")
         return self._token.access_token
 
+    @retry(
+        retry=retry_if_exception(_should_retry_request_http_error),
+        stop=stop_after_attempt(AZURE_TOTAL_RETRIES),
+        wait=wait_exponential(multiplier=AZURE_BACKOFF_FACTOR),
+        reraise=True,
+    )
     def _request(
         self, method: str, path: str, params: Optional[Dict[str, Any]] = None, **kwargs: Any
     ) -> requests.Response:
@@ -163,9 +180,11 @@ class PartnerPortalSession:
         formatted_url = self._prefix_url.format(**self.auth_keys)
         url = join_url(formatted_url, path)
         timeout = kwargs.pop("timeout", AZURE_SESSION_TIMEOUT)
-        return self.session.request(
+        response = self.session.request(
             method, url=url, params=params, headers=headers, timeout=timeout, **kwargs
         )
+        response.raise_for_status()
+        return response
 
     def get(self, path: str, **kwargs: Any) -> requests.Response:
         """Execute an API GET request."""

--- a/tests/ms_azure/test_session.py
+++ b/tests/ms_azure/test_session.py
@@ -1,14 +1,32 @@
 import importlib
 import os
 from datetime import datetime, timedelta
-from typing import Any, Dict
+from typing import Any, Dict, cast
 from unittest import mock
 
 import pytest
+import requests
 from httmock import response
+from requests import Response as RequestsResponse
 
-from cloudpub.ms_azure.session import AZURE_SESSION_TIMEOUT, AccessToken, PartnerPortalSession
+from cloudpub.ms_azure.session import (
+    AZURE_SESSION_TIMEOUT,
+    AZURE_TOTAL_RETRIES,
+    AccessToken,
+    PartnerPortalSession,
+    _should_retry_request_http_error,
+)
 from cloudpub.utils import join_url
+
+
+class TestShouldRetryRequestHttpError:
+    def test_returns_false_for_non_http_error(self) -> None:
+        assert not _should_retry_request_http_error(ValueError('not http'))
+
+    def test_returns_false_when_http_error_has_no_response(self) -> None:
+        exc = requests.exceptions.HTTPError(response=cast(RequestsResponse, None))
+        assert exc.response is None
+        assert not _should_retry_request_http_error(exc)
 
 
 class TestAccessToken:
@@ -233,3 +251,181 @@ class TestPartnerPortalSession:
                 headers=put_headers,
                 timeout=explicit_timeout,
             )
+
+    @staticmethod
+    def _http_error(status_code: int = 408) -> requests.exceptions.HTTPError:
+        resp = requests.Response()
+        resp.status_code = status_code
+        return requests.exceptions.HTTPError(response=resp)
+
+    @mock.patch('time.sleep')
+    @mock.patch("cloudpub.ms_azure.session.requests.Session")
+    def test_request_retries_on_http_error_then_succeeds(
+        self,
+        mock_session: mock.MagicMock,
+        _sleep: mock.MagicMock,
+        auth_dict: Dict[str, str],
+        token: Dict[str, str],
+    ) -> None:
+        """Transient HTTPError from the underlying request is retried; success returns normally."""
+        mock_session.return_value.post.return_value = response(200, token)
+        ok = response(200, {})
+        err = self._http_error()
+        mock_session.return_value.request.side_effect = [err, err, ok]
+
+        session = PartnerPortalSession.make_graph_api_session(
+            auth_dict, schema_version=auth_dict['AZURE_SCHEMA_VERSION']
+        )
+        out = session.get('/foo')
+
+        assert out is ok
+        assert mock_session.return_value.request.call_count == 3
+
+    @mock.patch('time.sleep')
+    @mock.patch("cloudpub.ms_azure.session.requests.Session")
+    def test_request_stops_after_max_retries_on_persistent_http_error(
+        self,
+        mock_session: mock.MagicMock,
+        _sleep: mock.MagicMock,
+        auth_dict: Dict[str, str],
+        token: Dict[str, str],
+    ) -> None:
+        """The HTTPError on every attempt stops after AZURE_TOTAL_RETRIES and reraises."""
+        mock_session.return_value.post.return_value = response(200, token)
+        err = self._http_error(500)
+        mock_session.return_value.request.side_effect = err
+
+        session = PartnerPortalSession.make_graph_api_session(
+            auth_dict, schema_version=auth_dict['AZURE_SCHEMA_VERSION']
+        )
+        with pytest.raises(requests.exceptions.HTTPError) as exc_info:
+            session.get('/foo')
+
+        assert exc_info.value is err
+        assert mock_session.return_value.request.call_count == AZURE_TOTAL_RETRIES
+
+    @pytest.mark.parametrize('status', [400, 407, 513])
+    @mock.patch('time.sleep')
+    @mock.patch("cloudpub.ms_azure.session.requests.Session")
+    def test_request_does_not_retry_http_error_outside_status_range(
+        self,
+        mock_session: mock.MagicMock,
+        _sleep: mock.MagicMock,
+        status: int,
+        auth_dict: Dict[str, str],
+        token: Dict[str, str],
+    ) -> None:
+        """The HTTPError outside 408–512 is not retried."""
+        mock_session.return_value.post.return_value = response(200, token)
+        err = self._http_error(status)
+        mock_session.return_value.request.side_effect = err
+
+        session = PartnerPortalSession.make_graph_api_session(
+            auth_dict, schema_version=auth_dict['AZURE_SCHEMA_VERSION']
+        )
+        with pytest.raises(requests.exceptions.HTTPError) as exc_info:
+            session.get('/foo')
+
+        assert exc_info.value is err
+        assert mock_session.return_value.request.call_count == 1
+
+    @mock.patch('time.sleep')
+    @mock.patch("cloudpub.ms_azure.session.requests.Session")
+    def test_request_does_not_retry_http_error_without_response(
+        self,
+        mock_session: mock.MagicMock,
+        _sleep: mock.MagicMock,
+        auth_dict: Dict[str, str],
+        token: Dict[str, str],
+    ) -> None:
+        """The HTTPError with no attached response is not retried (cannot map to status range)."""
+        mock_session.return_value.post.return_value = response(200, token)
+        err = requests.exceptions.HTTPError(response=cast(RequestsResponse, None))
+        assert err.response is None
+        mock_session.return_value.request.side_effect = err
+
+        session = PartnerPortalSession.make_graph_api_session(
+            auth_dict, schema_version=auth_dict['AZURE_SCHEMA_VERSION']
+        )
+        with pytest.raises(requests.exceptions.HTTPError) as exc_info:
+            session.get('/foo')
+
+        assert exc_info.value is err
+        assert mock_session.return_value.request.call_count == 1
+
+    @pytest.mark.parametrize(
+        'error',
+        [
+            ValueError('not an http error'),
+            requests.exceptions.ConnectionError('connection refused'),
+        ],
+    )
+    @mock.patch('time.sleep')
+    @mock.patch("cloudpub.ms_azure.session.requests.Session")
+    def test_request_does_not_retry_non_http_error(
+        self,
+        mock_session: mock.MagicMock,
+        _sleep: mock.MagicMock,
+        error: Exception,
+        auth_dict: Dict[str, str],
+        token: Dict[str, str],
+    ) -> None:
+        """The retry policy only applies to HTTPError; other exceptions are not retried."""
+        mock_session.return_value.post.return_value = response(200, token)
+        mock_session.return_value.request.side_effect = error
+
+        session = PartnerPortalSession.make_graph_api_session(
+            auth_dict, schema_version=auth_dict['AZURE_SCHEMA_VERSION']
+        )
+        with pytest.raises(type(error)) as exc_info:
+            session.get('/foo')
+
+        assert exc_info.value is error
+        assert mock_session.return_value.request.call_count == 1
+
+    @mock.patch('time.sleep')
+    @mock.patch("cloudpub.ms_azure.session.requests.Session")
+    def test_request_retries_after_raise_for_status_on_transient_http_status(
+        self,
+        mock_session: mock.MagicMock,
+        _sleep: mock.MagicMock,
+        auth_dict: Dict[str, str],
+        token: Dict[str, str],
+    ) -> None:
+        """503 from the transport + default raise_for_status triggers retry, then succeeds."""
+        mock_session.return_value.post.return_value = response(200, token)
+        err_503 = response(503, {})
+        ok = response(200, {})
+        mock_session.return_value.request.side_effect = [err_503, err_503, ok]
+
+        session = PartnerPortalSession.make_graph_api_session(
+            auth_dict, schema_version=auth_dict['AZURE_SCHEMA_VERSION']
+        )
+        out = session.get('/foo')
+
+        assert out is ok
+        assert mock_session.return_value.request.call_count == 3
+
+    @mock.patch('time.sleep')
+    @mock.patch("cloudpub.ms_azure.session.requests.Session")
+    def test_request_retries_after_raise_for_status_on_status_512_upper_bound(
+        self,
+        mock_session: mock.MagicMock,
+        _sleep: mock.MagicMock,
+        auth_dict: Dict[str, str],
+        token: Dict[str, str],
+    ) -> None:
+        """512 is the inclusive upper bound of retriable statuses; first attempt is retried."""
+        mock_session.return_value.post.return_value = response(200, token)
+        err_512 = response(512, {})
+        ok = response(200, {})
+        mock_session.return_value.request.side_effect = [err_512, ok]
+
+        session = PartnerPortalSession.make_graph_api_session(
+            auth_dict, schema_version=auth_dict['AZURE_SCHEMA_VERSION']
+        )
+        out = session.get('/foo')
+
+        assert out is ok
+        assert out.status_code == 200
+        assert mock_session.return_value.request.call_count == 2


### PR DESCRIPTION
This commit changes the `PartnerPortalSession` to rely on `tenacity` for retries on HTTPError instead of mounting an adapter with the retries from `urllib3`.

It also increases the HTTPError range from `500-512` to `408-512` in order to caught more exceptions in the retry logic.

This aims to fix some issues with the retrying mechanism we found.

Refers to SPSTRAT-725

Signed-off-by: Jonathan Gangi <jgangi@redhat.com>

Assisted-by: Cursor/Gemini

## Summary by Sourcery

Rework Azure PartnerPortalSession HTTP retry handling to use a tenacity-based policy with explicit status-code-based retry rules and raise-for-status semantics.

Enhancements:
- Introduce configurable Azure retry settings (total retries, backoff factor, and retriable HTTP status range 408–512) for PartnerPortalSession requests.
- Replace urllib3 adapter-based retries with a tenacity retry decorator around the internal request method, including raise_for_status integration.

Tests:
- Add unit tests covering HTTPError retry behavior, including success after transient failures, stopping after the configured maximum attempts, non-retriable status codes, errors without responses, and non-HTTP exceptions.
- Add tests for the helper that determines whether an HTTPError should be retried based on the attached response and status code.