### PR TITLE
Azure: update AZURE_SESSION_TIMEOUT to 15s

### DIFF
--- a/cloudpub/ms_azure/session.py
+++ b/cloudpub/ms_azure/session.py
@@ -11,7 +11,7 @@ from cloudpub.utils import base_url, join_url
 
 log = logging.getLogger(__name__)
 
-AZURE_SESSION_TIMEOUT: float = float(os.environ.get("AZURE_SESSION_TIMEOUT", 5.0))
+AZURE_SESSION_TIMEOUT: float = float(os.environ.get("AZURE_SESSION_TIMEOUT", 15.0))
 
 
 class AccessToken:


### PR DESCRIPTION
Azure: update AZURE_SESSION_TIMEOUT to 15s

Refers to SPSTRAT-725

## Summary by Sourcery

Enhancements:
- Relax the Azure session timeout by updating the default AZURE_SESSION_TIMEOUT value from 5 to 15 seconds.