### PR TITLE
Release v1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.7.2 - 2026-05-04
+
+- Azure: update AZURE_SESSION_TIMEOUT to 15s by @JAVGan in https://github.com/release-engineering/cloudpub/pull/195
+- Azure: Add unit-tests to ensure HTTPS retry mechanism works by @JAVGan in https://github.com/release-engineering/cloudpub/pull/194
+
 ## 1.7.1 - 2026-04-27
 
 - AWS: Fix bug on PromotionalResources model by @JAVGan in https://github.com/release-engineering/cloudpub/pull/180

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name='cloudpub',
     description='Services for publishing products in cloud environments',
-    version='1.7.1',
+    version='1.7.2',
     keywords='stratosphere cloudpub cloudpublish',
     author='Jonathan Gangi',
     author_email='jgangi@redhat.com',


### PR DESCRIPTION
Changes:

- Azure: update AZURE_SESSION_TIMEOUT to 15s by @JAVGan in https://github.com/release-engineering/cloudpub/pull/195
- Azure: Add unit-tests to ensure HTTPS retry mechanism works by @JAVGan in https://github.com/release-engineering/cloudpub/pull/194

## Summary by Sourcery

Release version 1.7.2 with updated Azure session timeout and documented HTTPS retry tests.

Enhancements:
- Adjust Azure session timeout configuration to 15 seconds.

Build:
- Bump package version from 1.7.1 to 1.7.2 in setup metadata.

Documentation:
- Add changelog entry for the 1.7.2 release including Azure timeout and HTTPS retry test updates.