### PR TITLE
fix: use pre-3.10 type annotations for compatibility

### DIFF
--- a/tests/ms_azure/test_session.py
+++ b/tests/ms_azure/test_session.py
@@ -3,7 +3,7 @@ import os
 import threading
 from datetime import datetime, timedelta
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Type
 from unittest import mock
 
 import pytest
@@ -238,7 +238,7 @@ class TestPartnerPortalSession:
             )
 
 
-def _start_local_server(handler: type[BaseHTTPRequestHandler]) -> tuple[HTTPServer, int]:
+def _start_local_server(handler: Type[BaseHTTPRequestHandler]) -> Tuple[HTTPServer, int]:
     server = HTTPServer(("127.0.0.1", 0), handler)
     port = server.server_address[1]
     threading.Thread(target=server.serve_forever, daemon=True).start()
@@ -246,8 +246,8 @@ def _start_local_server(handler: type[BaseHTTPRequestHandler]) -> tuple[HTTPServ
 
 
 def _sequential_http_handler(
-    responses: List[Tuple[int, bytes | None]],
-) -> tuple[type[BaseHTTPRequestHandler], List[int]]:
+    responses: List[Tuple[int, Optional[bytes]]],
+) -> Tuple[Type[BaseHTTPRequestHandler], List[int]]:
     """Build a handler that returns each (status, body) in order for GET/PUT."""
     call_count = [0]
 


### PR DESCRIPTION
## Summary
- Replace PEP 604 union syntax (`bytes | None`) with `Optional[bytes]` in `tests/ms_azure/test_session.py`
- Replace builtin generic types (`tuple[]`, `type[]`) with `typing` equivalents (`Tuple`, `Type`) for Python < 3.10 compatibility

Refers to SPSTRAT-731

## Test plan
- [ ] Verify tests pass on Python 3.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update Azure session tests to use pre-3.10 compatible type annotations.

Enhancements:
- Align type hints in Azure session tests with typing module generics for Python versions prior to 3.10.

Tests:
- Adjust type annotations in Azure session test helpers to maintain compatibility with Python 3.9.