### PR TITLE
Revert "Drop support for python 3.9"

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: 3.9
       - name: Install OS packages
         run: |
           sudo apt-get -y update

--- a/.github/workflows/pip-compile.yml
+++ b/.github/workflows/pip-compile.yml
@@ -12,7 +12,7 @@ jobs:
      - name: Setup Python
        uses: actions/setup-python@v6
        with:
-         python-version: "3.10"
+         python-version: "3.9"
 
      - name: Install system dependencies
        run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.10'
+        python-version: '3.9'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: 3.9
       - name: Install Tox
         run: pip install tox 'virtualenv<20.21.1'
       - name: Run Linting
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: 3.9
       - name: Install Tox
         run: pip install tox 'virtualenv<20.21.1'
       - name: Run MyPy
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         # https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
@@ -72,7 +72,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: 3.9
       - name: Install Tox
         run: pip install tox 'virtualenv<20.21.1'
       - name: Install pytest cov
@@ -91,7 +91,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: 3.9
       - name: Install Tox
         run: pip install tox
       - name: Run Tox
@@ -175,7 +175,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: 3.9
       - name: Install Tox
         run: pip install tox 'virtualenv<20.21.1'
       - name: Run Tox

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To install this library go to the project's root directory and execute:
 
 The versions listed below are the one which were tested and work. Other versions can work as well.
 
-- Install or create a `virtualenv` for `python` >= 3.10
+- Install or create a `virtualenv` for `python` >= 3.8
 - Install `tox` >= 3.25
 
 ### Dependency Management
@@ -89,4 +89,4 @@ To automatically format your code you man run `tox -e autoformat`.
 
 ### Unit tests
 
-To run unit tests use `tox -e py310,py311,py312,py313`.
+To run unit tests use `tox -e py38,py39,py310,py311`.

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     include_package_data=True,
     classifiers=[
         'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pip-compile, docs, lint, mypy, security, py310, py311, py312, py313
+envlist = pip-compile, docs, lint, mypy, security, py39, py310, py311, py312, py313
 
 [testenv]
 envdir = {toxworkdir}/shared-environment
@@ -13,7 +13,7 @@ commands=
         --cov-report xml --cov-report html {posargs}
 
 [testenv:pip-compile]
-basepython = python3.10
+basepython = python3.9
 skip_install = true
 deps =
     pip-tools
@@ -37,11 +37,11 @@ deps =
     isort
 commands = 
     flake8 --max-line-length=100 --ignore=D100,D104,D105 --per-file-ignores=tests/*:D101,D102,D103 cloudpub tests
-    black -S -t py310 -l 100 --check --diff cloudpub tests
+    black -S -t py39 -l 100 --check --diff cloudpub tests
     isort -l 100 --profile black --check --diff cloudpub tests
 
 [testenv:mypy]
-basepython = python3.10
+basepython = python3.9
 deps = -r requirements-test.txt
 commands = mypy --warn-unused-ignores --ignore-missing-imports --exclude '^venv.*' .
 
@@ -60,7 +60,7 @@ deps =
     black >= 23.1.0
     isort
 commands = 
-    black -S -t py310 -l 100 cloudpub tests
+    black -S -t py39 -l 100 cloudpub tests
     isort -l 100 --profile black cloudpub tests
 
 [testenv:azure_schemas]
@@ -69,7 +69,7 @@ deps = -r requirements.txt
 commands = python schemas/download_azure_schemas.py {posargs}
 
 [testenv:coverage]
-basepython = python3.10
+basepython = python3.9
 deps = -r requirements-test.txt
 relative_files = True
 usedevelop= True


### PR DESCRIPTION
This reverts commit f922a4393ebf89b5f4e37b5f3bca82bf2489a9ed.

## Summary by Sourcery

Restore Python 3.9 as a supported and tested runtime across CI, tooling, and packaging metadata.

Enhancements:
- Reinstate Python 3.9 environments in tox configuration and adjust linting/formatting targets accordingly.

Build:
- Update setup.py classifiers to include Python 3.9 support.

CI:
- Update GitHub Actions workflows to run tests, docs, and packaging jobs using Python 3.9 and to add 3.9 back into the test matrix.

Documentation:
- Revise README to document support and test instructions for Python 3.8 and 3.9.