### PR TITLE
tox: drop safety in favor of pip-audit only

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,8 @@ envlist = pip-compile, docs, lint, mypy, security, py310, py311, py312, py313
 
 [testenv]
 envdir = {toxworkdir}/shared-environment
+setenv =
+    PIP_INDEX_URL = {env:PIP_INDEX_URL:https://pypi.org/simple/}
 deps=
     -r requirements-test.txt
 usedevelop=true
@@ -49,10 +51,12 @@ commands = mypy --warn-unused-ignores --ignore-missing-imports --exclude '^venv.
 skip_install = true
 deps = 
     bandit
-    safety
+    pip-audit
+
 commands = 
     bandit -s B303 -r cloudpub
-    safety check -r requirements.txt
+    pip-audit -S -s pypi --index-url {env:PIP_INDEX_URL} -r requirements.txt
+    pip-audit -S -s osv --index-url {env:PIP_INDEX_URL} -r requirements.txt
 
 [testenv:autoformat]
 skip_install = true


### PR DESCRIPTION
tox: drop safety in favor of pip-audit only

## Summary by Sourcery

Build:
- Update tox security environment dependencies and commands to drop safety and run pip-audit against the configured package index using both PyPI and OSV vulnerability sources.