### PR TITLE
models: Make Manufacturer optional in ProductDetailDescription

### DIFF
--- a/cloudpub/models/aws.py
+++ b/cloudpub/models/aws.py
@@ -363,7 +363,9 @@ class ProductDetailDescription(AttrsJSONDecodeMixin):
     long_description: str = field(validator=instance_of(str), metadata={"alias": "LongDescription"})
     """A detailed description of the product."""
 
-    manufacturer: str = field(validator=instance_of(str), metadata={"alias": "Manufacturer"})
+    manufacturer: Optional[str] = field(
+        validator=optional(instance_of(str)), metadata={"alias": "Manufacturer"}
+    )
     """The product's manufacturer name."""
 
     product_state: str = field(validator=instance_of(str), metadata={"alias": "ProductState"})

--- a/tests/aws/test_models.py
+++ b/tests/aws/test_models.py
@@ -125,6 +125,17 @@ def test_describe_entity_response_parsed_details(
     assert isinstance(resp.details_document, ProductDetailResponse)
 
 
+def test_describe_entity_response_no_manufacturer_parsed_details(
+    describe_entity_response_base: Dict[str, Any], details_entity_json: Dict[str, Any]
+) -> None:
+    data = deepcopy(details_entity_json)
+    data["Description"]["Manufacturer"] = None
+    describe_entity_response_base["Details"] = json.dumps(data)
+    describe_entity_response_base["DetailsDocument"] = data
+    resp = DescribeEntityResponse.from_json(describe_entity_response_base)
+    assert isinstance(resp.details_document, ProductDetailResponse)
+
+
 def test_list_changeset_response_parsed(list_changeset_response: Dict[str, Any]) -> None:
     resp = ListChangeSetsResponse.from_json(list_changeset_response)
     assert len(resp.change_set_list) == 1


### PR DESCRIPTION
The field Manufacturer used to be part of Product details e.g.
```
sh$ aws marketplace-catalog describe-entity --catalog "AWSMarketplace" \
        --entity-id 6b2625ac-e9ca-4d9a-a34f-63dc75a4d497 \
    | jq .DetailsDocument.Description
{
  "ProductTitle": "Red Hat Enterprise Linux (RHEL) for AWS",
  "ShortDescription": "For North America and regions //snip",
  "Manufacturer": "Red Hat®",
```
But it was removed in https://github.com/awslabs/aws-marketplace-catalog-api-shapes-for-python/pull/2 when code-base dropped the preview state in 1.0.0

It was there just in aws-marketplace-catalog-api-shape-library-for-python-0.1.0.

It is still returned for old products but one cannot set the field in AWS Marketpalce Management Portal anymore.

Therefore we make it just optional.

AWS marketpalce API still returns it as a null for new products
```
sh$ aws marketplace-catalog describe-entity --catalog "AWSMarketplace" \
        --entity-id prod-2eh26tq6hauhe | jq .DetailsDocument.Description
{
  "ProductTitle": "Red Hat Enterprise Linux AI",
  "ShortDescription": "Red Hat® Enterprise Linux® AI //snip",
  "Manufacturer": null,
```

## Summary by Sourcery

Make the Manufacturer field in product detail descriptions optional to match current AWS Marketplace behavior and ensure responses without a manufacturer are handled correctly.

Bug Fixes:
- Allow parsing of product detail descriptions where Manufacturer is null or omitted without raising validation errors.

Tests:
- Add a test to verify that describe-entity responses with a null Manufacturer field are successfully parsed into product detail responses.