### PR TITLE
fix(SPSTRAT-760): Sort resources by durable ID before diffing offers and update DIFF EXCLUDE

### DIFF
--- a/cloudpub/ms_azure/service.py
+++ b/cloudpub/ms_azure/service.py
@@ -90,7 +90,11 @@ class AzureService(BaseService[AzurePublishingMetadata]):
     AZURE_API_VERSION = os.environ.get("AZURE_API_VERSION", "2022-07-01")
     AZURE_SCHEMA_VERSION = os.environ.get("AZURE_SCHEMA_VERSION", "2022-07-01")
     CONFIGURE_SCHEMA = "https://schema.mp.microsoft.com/schema/configure/{AZURE_API_VERSION}"
-    DIFF_EXCLUDES = [r"root\['resources'\]\[[0-9]+\]\['url'\]"]
+    DIFF_EXCLUDES = [
+        r"root\['target'\]\['targetType'\]",
+        r"root\['resources'\]\[\d+\]\['url'\]",
+        r"root\['resources'\]\[\d+\]\['assets'\]\['[^']+'\]\['imageList'\]\[\d+\]\['url'\]",
+    ]
 
     def __init__(
         self,

--- a/cloudpub/ms_azure/service.py
+++ b/cloudpub/ms_azure/service.py
@@ -450,6 +450,35 @@ class AzureService(BaseService[AzurePublishingMetadata]):
                 NotFoundError, f"No such plan with name \"{plan_name} for {product_name}\""
             )
 
+    @staticmethod
+    def _prepare_resources_for_diff(offer_json: dict) -> dict:
+        """Prepare the offer JSON for diffing by sorting and filtering resources.
+
+        The Product Ingestion API does not guarantee the order of resources in the
+        resource-tree response. Sorting by durable ID ensures that DeepDiff compares
+        matching resources rather than resources that happen to share the same index.
+
+        Submission resources are filtered out as they always differ between submission
+        targets (e.g. draft vs live) due to their target-specific durable ID, status,
+        result and created fields.
+
+        Args:
+            offer_json (dict)
+                The serialized product JSON.
+        Returns:
+            dict: The product JSON with resources sorted and filtered.
+        """
+        prepared = offer_json.copy()
+        prepared["resources"] = sorted(
+            (
+                r
+                for r in offer_json["resources"]
+                if not (r.get("id") or "").startswith("submission/")
+            ),
+            key=lambda r: r.get("id", ""),
+        )
+        return prepared
+
     def diff_offer(self, product: Product, target: str) -> DeepDiff:
         """Compute the difference between the provided product and the one in the remote.
 
@@ -462,7 +491,11 @@ class AzureService(BaseService[AzurePublishingMetadata]):
             DeepDiff: The diff data.
         """
         remote = self.get_product(product.id, target=target)
-        return DeepDiff(remote.to_json(), product.to_json(), exclude_regex_paths=self.DIFF_EXCLUDES)
+        return DeepDiff(
+            self._prepare_resources_for_diff(remote.to_json()),
+            self._prepare_resources_for_diff(product.to_json()),
+            exclude_regex_paths=self.DIFF_EXCLUDES,
+        )
 
     def diff_two_offers(self, last_offer: Product, prev_offer: Product) -> DeepDiff:
         """Compute the difference between two provided products.
@@ -476,7 +509,9 @@ class AzureService(BaseService[AzurePublishingMetadata]):
             DeepDiff: The diff data.
         """
         return DeepDiff(
-            prev_offer.to_json(), last_offer.to_json(), exclude_regex_paths=self.DIFF_EXCLUDES
+            self._prepare_resources_for_diff(prev_offer.to_json()),
+            self._prepare_resources_for_diff(last_offer.to_json()),
+            exclude_regex_paths=self.DIFF_EXCLUDES,
         )
 
     def submit_to_status(

--- a/tests/ms_azure/test_service.py
+++ b/tests/ms_azure/test_service.py
@@ -581,9 +581,10 @@ class TestAzureService:
         data_product["resources"][0]["id"] = "product/foo/bar"
 
         diff = azure_service.diff_offer(Product.from_json(data_product), target=target)
+        # After sorting by durable ID the product resource is at index 7
         assert diff == {
             'values_changed': {
-                "root['resources'][0]['id']": {
+                "root['resources'][7]['id']": {
                     'new_value': 'product/foo/bar',
                     'old_value': 'product/ffffffff-ffff-ffff-ffff-ffffffffffff',
                 },
@@ -600,14 +601,50 @@ class TestAzureService:
         last_offer = Product.from_json(data_product)
 
         diff = azure_service.diff_two_offers(last_offer, product_obj)
+        # After sorting by durable ID the product resource is at index 7
         assert diff == {
             'values_changed': {
-                "root['resources'][0]['id']": {
+                "root['resources'][7]['id']": {
                     'new_value': 'product/foo/bar',
                     'old_value': 'product/ffffffff-ffff-ffff-ffff-ffffffffffff',
                 },
             },
         }
+
+    def test_diff_two_offers_reordered_resources(
+        self,
+        azure_service: AzureService,
+        product_obj: Product,
+    ) -> None:
+        data_product = deepcopy(product_obj.to_json())
+        data_product["resources"] = list(reversed(data_product["resources"]))
+        reordered_offer = Product.from_json(data_product)
+
+        assert azure_service.diff_two_offers(reordered_offer, product_obj) == {}
+
+    def test_prepare_resources_for_diff_filters_submission(
+        self,
+        product_obj: Product,
+    ) -> None:
+        offer_json = product_obj.to_json()
+        # Ensure the fixture has a submission resource
+        submission_ids = [
+            r["id"] for r in offer_json["resources"] if r["id"].startswith("submission/")
+        ]
+        assert submission_ids, "Fixture should contain a submission resource"
+
+        prepared = AzureService._prepare_resources_for_diff(offer_json)
+
+        # Submission resources must be filtered out
+        prepared_ids = [r["id"] for r in prepared["resources"]]
+        for sid in submission_ids:
+            assert sid not in prepared_ids
+
+        # Non-submission resources must be preserved
+        assert len(prepared["resources"]) == len(offer_json["resources"]) - len(submission_ids)
+
+        # Resources must be sorted by durable ID
+        assert prepared_ids == sorted(prepared_ids)
 
     @pytest.mark.parametrize("target", ["preview", "live", "draft"])
     @mock.patch("cloudpub.ms_azure.AzureService.get_product")
@@ -2511,9 +2548,11 @@ class TestAzureService:
 
         # Present messages
         assert "The DiskVersion doesn't exist, creating one from scratch." in caplog.text
+        # After sorting by durable ID (with submission filtered out)
+        # the technical config resource is at index 11
         assert (
             "Found the following offer diff before publishing:\n"
-            "Item root['resources'][1]['vmImageVersions'][1] added to iterable."
+            "Item root['resources'][11]['vmImageVersions'][1] added to iterable."
         ) in caplog.text
         assert (
             'Updating the technical configuration for "example-product/plan-1" on "draft".'


### PR DESCRIPTION
The Product Ingestion API does not guarantee the order of resources in resource-tree responses. When draft and live versions return resources in different order, DeepDiff compares unrelated resource types at the same index, producing false diffs that block publishing.

Sort the resources list by durable ID (which is stable and permanent per the API documentation) before passing to DeepDiff, ensuring matching resources are compared against each other.

Ref: https://learn.microsoft.com/en-us/partner-center/marketplace-offers/product-ingestion-api#durable-id

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Sort Azure offer resources by durable ID and filter out submission resources before diffing to avoid spurious differences caused by resource ordering and target-specific metadata.

Bug Fixes:
- Prevent false-positive diffs when draft and live Azure offers return resources in different orders by sorting resources by durable ID prior to comparison.
- Exclude target-specific submission resources and various URL/image fields from Azure offer diffs to avoid noisy, non-actionable differences.

Tests:
- Extend Azure service tests to cover diff behavior with reordered resources, verify submission resources are filtered and sorted by durable ID, and update existing expectations for changed resource indices in diffs.