### PR TITLE
Release v1.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.7.4 - 2026-07-07
+
+- fix(SPSTRAT-760): Sort resources by durable ID before diffing offers and update DIFF EXCLUDE by @lslebodn in https://github.com/release-engineering/cloudpub/pull/210
+- Do not retry on certification errors by @ashwgit in https://github.com/release-engineering/cloudpub/pull/211
+- Update dependencies
+
 ## 1.7.3 - 2026-05-26
 
 - models: Make Manufacturer optional in ProductDetailDescription by @lslebodn in https://github.com/release-engineering/cloudpub/pull/205

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name='cloudpub',
     description='Services for publishing products in cloud environments',
-    version='1.7.3',
+    version='1.7.4',
     keywords='stratosphere cloudpub cloudpublish',
     author='Jonathan Gangi',
     author_email='jgangi@redhat.com',


### PR DESCRIPTION
Changes:

- fix(SPSTRAT-760): Sort resources by durable ID before diffing offers and update DIFF EXCLUDE by @lslebodn in https://github.com/release-engineering/cloudpub/pull/210
- Do not retry on certification errors by @ashwgit in https://github.com/release-engineering/cloudpub/pull/211
- Update dependencies

## Summary by Sourcery

Prepare the 1.7.4 release of cloudpub with documented changes and updated packaging metadata.

Bug Fixes:
- Document sorting resources by durable ID before diffing offers and updating DIFF EXCLUDE.
- Document disabling retries on certification errors.

Enhancements:
- Update project dependencies for the 1.7.4 release.

Build:
- Bump package version to 1.7.4 in setup configuration.

Documentation:
- Add 1.7.4 release notes to the changelog.