### PR TITLE
fix: update AZURE_SESSION_TIMEOUT to 20.0

### DIFF
--- a/cloudpub/ms_azure/session.py
+++ b/cloudpub/ms_azure/session.py
@@ -11,7 +11,7 @@ from cloudpub.utils import base_url, join_url
 
 log = logging.getLogger(__name__)
 
-AZURE_SESSION_TIMEOUT: float = float(os.environ.get("AZURE_SESSION_TIMEOUT", 15.0))
+AZURE_SESSION_TIMEOUT: float = float(os.environ.get("AZURE_SESSION_TIMEOUT", 20.0))
 
 
 class AccessToken:


### PR DESCRIPTION
Bump `AZURE_SESSION_TIMEOUT` from 15.0s to 20.0s

Refers to SPSTRAT-758

## Summary by Sourcery

Enhancements:
- Adjust the AZURE_SESSION_TIMEOUT environment-based default to 20.0 seconds to allow longer Azure sessions before timeout.